### PR TITLE
ログイン前後による共通レイアウトのテストを実装

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -12,7 +12,7 @@
       <div class="form-group mt-30">
         <%= f.label :password, "パスワード", class: "form-label" %>
         <%= link_to("(パスワードをお忘れの方はこちら)", '#') %>
-        <%= f.text_field :password, class: "form-control", placeholder: "パスワードを入力してください" %>
+        <%= f.password_field :password, class: "form-control", placeholder: "パスワードを入力してください" %>
       </div>
 
       <div class="text-center mt-30">

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe "StaticPages", type: :system do
+  let(:user) { create(:user, password: 'password') }
+
+  describe 'ページ遷移の確認' do
+    describe 'ログイン前' do
+      context 'トップページにアクセスする' do
+        it 'アクセスが成功する' do
+          visit root_path
+          expect(page).to have_title page_title(''), exact: true
+          expect(page).to have_link 'ユーザーチューブ', href: root_path
+          expect(page).to have_link 'ユーザー登録', href: signup_path
+          expect(page).to have_link 'ログイン', href: login_path
+          expect(page).to have_link 'ユーザー一覧', href: '#'
+          expect(page).to have_link 'チャンネル一覧', href: '#'
+          expect(page).to have_link '高評価動画一覧', href: '#'
+          expect(page).to have_link '投稿一覧', href: '#'
+          expect(page).to have_link '新着コンテンツ一覧', href: '#'
+          expect(page).to have_link '実際に使ってみる！', href: '#'
+          expect(page).to have_link 'トップページ', href: '#'
+          expect(page).to have_link '利用規約', href: '#'
+          expect(page).to have_link 'プライバシーポリシー', href: '#'
+          expect(page).to have_link 'GitHub', href: '#'
+          expect(page).to have_link 'Qiita', href: '#'
+          expect(page).to have_link 'wantedly', href: '#'
+        end
+      end
+    end
+
+    describe 'ログイン後' do
+      context 'トップページにアクセスする' do
+        it 'アクセスが成功する' do
+          login_as(user)
+          click_link 'ユーザーチューブ'
+          expect(page).to have_title page_title(''), exact: true
+          expect(page).to have_link 'ユーザーチューブ', href: root_path
+          expect(page).to have_link user.name, href: '#'
+          expect(page).to have_link 'ユーザー一覧', href: '#'
+          expect(page).to have_link 'チャンネル一覧', href: '#'
+          expect(page).to have_link '高評価動画一覧', href: '#'
+          expect(page).to have_link '投稿一覧', href: '#'
+          expect(page).to have_link '新着コンテンツ一覧', href: '#'
+          expect(page).to have_link '実際に使ってみる！', href: '#'
+          expect(page).to have_link 'トップページ', href: '#'
+          expect(page).to have_link '利用規約', href: '#'
+          expect(page).to have_link 'プライバシーポリシー', href: '#'
+          expect(page).to have_link 'GitHub', href: '#'
+          expect(page).to have_link 'Qiita', href: '#'
+          expect(page).to have_link 'wantedly', href: '#'
+          click_link user.name
+          expect(page).to have_link 'マイページ', href: '#'
+          expect(page).to have_link 'ユーザーの編集', href: '#'
+          expect(page).to have_link 'ログアウト', href: logout_path
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 変更の概要

* Close #9 

## 変更内容

* テスト結果
[![Image from Gyazo](https://i.gyazo.com/7cc70bc412bfafe921ba8ec61aadb17e.png)](https://gyazo.com/7cc70bc412bfafe921ba8ec61aadb17e)

## 備考

* 今回のテストでは実装済みのリンクの確認のみを行なっているため、今後の実装が完了次第、リンク先を追加予定
