### PR TITLE
ユーザー一覧ページにページネーションを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ gem "sorcery"
 gem "enum_help"
 gem "config"
 gem "faker"
+gem "kaminari"
+gem "bootstrap5-kaminari-views"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,9 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    bootstrap5-kaminari-views (0.0.1)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     builder (3.2.4)
     capybara (3.39.2)
       addressable
@@ -178,6 +181,18 @@ GEM
       activesupport (>= 5.0.0)
     json (2.6.3)
     jwt (2.7.1)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
@@ -385,6 +400,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   bootstrap-sass
+  bootstrap5-kaminari-views
   capybara
   config
   debug
@@ -394,6 +410,7 @@ DEPENDENCIES
   faker
   importmap-rails
   jbuilder
+  kaminari
   letter_opener_web (~> 2.0)
   mysql2 (~> 0.5)
   pg

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -59,6 +59,17 @@ footer {
   }
 }
 
+/* ページネーション */
+.pagination>li>a {          
+  border: none;
+  color: #696969;
+  font-size: 16px;
+}
+
+.pagination>.active>a {     
+  background: #93c9ff;
+}
+
 /* ユーザー一覧 */
 .user-card {
   padding: 10px;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
   before_action :require_not_login
 
   def index
-    @users = User.all
+    @users = User.all.page(params[:page])
   end
 
   def new

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,6 +3,8 @@
 
 <div class="row">
   <div class="col-md-8 col-md-offset-2">
+    <span class="text-center"><%= paginate @users, theme: 'bootstrap-5' %></span>
     <%= render @users %>
+    <span class="text-center"><%= paginate @users, theme: 'bootstrap-5' %></span>
   </div>
 </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 30
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/views/kaminari_japanese.yml
+++ b/config/locales/views/kaminari_japanese.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -84,10 +84,14 @@ RSpec.describe "Users", type: :system do
         it '登録済みのユーザーが表示される' do
           visit root_path
           click_on 'ユーザー一覧'
-          User.all.each do |user|
+          expect(page).to have_selector 'ul.pagination'
+          User.all.page(1).each do |user|
             expect(page).to have_content user.name
           end
-          expect(page).to have_title page_title('ユーザー一覧'), exact: true
+          click_link "次", match: :first
+          User.all.page(2).each do |user|
+            expect(page).to have_content user.name
+          end
         end
       end
     end


### PR DESCRIPTION
## 変更の概要

* gem(kiminari)を使用し、ページネーションを実装
* ユーザー一覧表示のテストを修正
* #11 

## やったこと

* [x] ページネーションの実装
* [X] ページネーションのテスト

## 変更内容

* ページネーションの表示
[![Image from Gyazo](https://i.gyazo.com/d493f885a0103a7203f871ca45b12a0b.png)](https://gyazo.com/d493f885a0103a7203f871ca45b12a0b)
* テスト結果
[![Image from Gyazo](https://i.gyazo.com/f798db3b1988a485ab2a962ea904b388.png)](https://gyazo.com/f798db3b1988a485ab2a962ea904b388)