### PR TITLE
ログイン中にユーザー一覧が開けない不具合を修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   skip_before_action :require_login
-  before_action :require_not_login
+  before_action :require_not_login, only: %i[new create confirm signup_check]
 
   def index
     @users = User.all.page(params[:page])
@@ -26,7 +26,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
   end
 
-  def signup_confirm
+  def signup_check
     @user = User.new(user_params)
     if @user.valid?
       redirect_to(confirm_users_url, user_params:)

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_with(model: @user, url: "/singup/confirm") do |f| %>
+    <%= form_with(model: @user, url: "/singup/check") do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
       <div class="form-group">
         <%= f.label :name, class: "form-label" %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,7 +8,7 @@ ja:
       success: ユーザー登録を行いました
     confirm:
       title: ユーザー登録(確認画面)
-    signup_confirm:
+    signup_check:
       danger: ユーザー登録に失敗しました
   user_sessions:
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   
   root "static_pages#top"
   get  "/signup", to: "users#new"
-  post "/singup/confirm", to: "users#signup_confirm"
+  post "/singup/check", to: "users#signup_check"
   get "/login", to: "user_sessions#new"
   post "/login", to: "user_sessions#create"
   delete "/logout", to: "user_sessions#destroy"

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
+  let(:user) { create(:user, password: 'password') }
+  
   describe 'ログイン前' do
     describe 'ユーザー新規登録' do
       context 'フォームの入力値が正常' do
@@ -75,6 +77,32 @@ RSpec.describe "Users", type: :system do
 
     describe 'ユーザー一覧' do
       before do
+        50.times do
+          create(:user)
+        end
+      end
+
+      context 'ユーザー一覧ページを表示' do
+        it '登録済みのユーザーが表示される' do
+          visit root_path
+          click_on 'ユーザー一覧'
+          expect(page).to have_selector 'ul.pagination'
+          User.all.page(1).each do |user|
+            expect(page).to have_content user.name
+          end
+          click_link "次", match: :first
+          User.all.page(2).each do |user|
+            expect(page).to have_content user.name
+          end
+        end
+      end
+    end
+  end
+
+  describe 'ログイン後' do
+    describe 'ユーザー一覧' do
+      before do
+        login_as(user)
         50.times do
           create(:user)
         end


### PR DESCRIPTION
## 変更の概要

* ログイン後でもユーザー一覧にアクセスできるように修正
* ログイン後にユーザー一覧にアクセスできることを確認するテストを追加
* 関連するプルリクエスト #62 