### PR TITLE
高評価動画 & 登録チャンネルの公開設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include ApplicationHelper
 
-  add_flash_types :success, :danger, :warning, :user_params
+  add_flash_types :success, :danger, :warning, :user_params, :setting_public
 
   def require_not_login
     redirect_to root_path, warning: '指定のページにアクセスするにはログアウトしてください' if logged_in?

--- a/app/controllers/google_login_api_controller.rb
+++ b/app/controllers/google_login_api_controller.rb
@@ -4,10 +4,11 @@ class GoogleLoginApiController < ApplicationController
   def callback
     auth = request.env['omniauth.auth']
     access_token = auth.credentials.token
+
     subscription_channels = Channel.subscription_channels(access_token)
     current_user.update_subscriptions(subscription_channels)
     pupular_videos = Video.popular_videos(access_token)
     current_user.update_popular_videos(pupular_videos)
-    redirect_to channels_user_url(current_user), success: '登録チャンネル/高評価動画を同期しました'
+    redirect_to edit_subscription_channels_path, success: '登録チャンネル/高評価動画を同期しました。登録チャンネルの公開設定を行ってください。', setting_public: true
   end
 end

--- a/app/controllers/popular_videos_controller.rb
+++ b/app/controllers/popular_videos_controller.rb
@@ -5,9 +5,9 @@ class PopularVideosController < ApplicationController
   def edit; end
 
   def update
-    @popular_videos.each_with_index do |popular_video, index|
+    @popular_videos.each do |popular_video|
       ActiveRecord::Base.transaction do
-        is_public = params["is_public#{index + 1}"] || false
+        is_public = params["is_public#{popular_video.id}"] || false
         popular_video.update!(is_public:)
       end
     rescue ActiveRecord::Rollback

--- a/app/controllers/popular_videos_controller.rb
+++ b/app/controllers/popular_videos_controller.rb
@@ -1,0 +1,25 @@
+class PopularVideosController < ApplicationController
+  before_action :require_login
+  before_action :set_popular_videos
+
+  def edit; end
+
+  def update
+    @popular_videos.each_with_index do |popular_video, index|
+      ActiveRecord::Base.transaction do
+        is_public = params["is_public#{index + 1}"] || false
+        popular_video.update!(is_public:)
+      end
+    rescue ActiveRecord::Rollback
+      flash.now[:danger] = t('.danger')
+      return render :edit, status: :unprocessable_entity
+    end
+    redirect_to videos_user_path(current_user), success: t('.success')
+  end
+
+  private
+
+  def set_popular_videos
+    @popular_videos = current_user.popular_videos
+  end
+end

--- a/app/controllers/subscription_channels_controller.rb
+++ b/app/controllers/subscription_channels_controller.rb
@@ -5,16 +5,21 @@ class SubscriptionChannelsController < ApplicationController
   def edit; end
 
   def update
-    @subscription_channels.each_with_index do |subscription_channel, index|
+    @subscription_channels.each do |subscription_channel|
       ActiveRecord::Base.transaction do
-        is_public = params["is_public#{index + 1}"] || false
+        is_public = params["is_public#{subscription_channel.id}"] || false
         subscription_channel.update!(is_public:)
       end
     rescue ActiveRecord::Rollback
       flash.now[:danger] = t('.danger')
       return render :edit, status: :unprocessable_entity
     end
-    redirect_to channels_user_path(current_user), success: t('.success')
+
+    if params[:setting_public]
+      redirect_to edit_popular_videos_path, success: 'チャンネルの公開設定を行いました。続けて、高評価動画の公開設定を行ってください。'
+    else
+      redirect_to channels_user_path(current_user), success: t('.success')
+    end
   end
 
   private

--- a/app/controllers/subscription_channels_controller.rb
+++ b/app/controllers/subscription_channels_controller.rb
@@ -1,0 +1,25 @@
+class SubscriptionChannelsController < ApplicationController
+  before_action :require_login
+  before_action :set_subscription_channels
+
+  def edit; end
+
+  def update
+    @subscription_channels.each_with_index do |subscription_channel, index|
+      ActiveRecord::Base.transaction do
+        is_public = params["is_public#{index + 1}"] || false
+        subscription_channel.update!(is_public:)
+      end
+    rescue ActiveRecord::Rollback
+      flash.now[:danger] = t('.danger')
+      return render :edit, status: :unprocessable_entity
+    end
+    redirect_to channels_user_path(current_user), success: t('.success')
+  end
+
+  private
+
+  def set_subscription_channels
+    @subscription_channels = current_user.subscription_channels
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,7 +51,7 @@ class UsersController < ApplicationController
   end
 
   def channels
-    @channels = @user.channels.page(params[:page])
+    @channels = @user.subscription_channels_with_public.page(params[:page])
   end
 
   def videos

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -55,7 +55,7 @@ class UsersController < ApplicationController
   end
 
   def videos
-    @videos = @user.videos.page(params[:page]).per(8)
+    @videos = @user.popular_videos_with_public.page(params[:page]).per(8)
   end
 
   def contents

--- a/app/decorators/popular_video_decorator.rb
+++ b/app/decorators/popular_video_decorator.rb
@@ -1,0 +1,12 @@
+class PopularVideoDecorator < ApplicationDecorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+end

--- a/app/decorators/subscription_channel_decorator.rb
+++ b/app/decorators/subscription_channel_decorator.rb
@@ -1,0 +1,12 @@
+class SubscriptionChannelDecorator < ApplicationDecorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "custom/menu"
+import "custom/is_public"

--- a/app/javascript/custom/is_public.js
+++ b/app/javascript/custom/is_public.js
@@ -1,0 +1,18 @@
+document.addEventListener("turbo:load", function() {
+  let check_public = document.querySelector("#is_public");
+  if (check_public === null) {
+    return
+  }
+  check_public.addEventListener("change", (event) => {
+    let check_list = document.querySelectorAll(".is_public");
+    if (event.currentTarget.checked) {
+      for (let i = 0; i < check_list.length; i++) {
+        check_list[i].checked = true;
+      }
+    } else {
+      for (let i = 0; i < check_list.length; i++) {
+        check_list[i].checked = false;
+      }
+    }
+  });
+});

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,11 @@ class User < ApplicationRecord
   # 性別 { 回答なし: 0, 男性: 1, 女性: 2, その他: 9 }
   enum gender: { not_known: 0, male: 1, female: 2, not_applicabel: 9 }
 
+  def subscription_channels_with_public
+    subscription_channel_ids = subscription_channels.where(is_public: true).ids
+    channels.where(id: subscription_channel_ids)
+  end
+
   def follow(other_user)
     following << other_user unless self == other_user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,11 @@ class User < ApplicationRecord
     channels.where(id: subscription_channel_ids)
   end
 
+  def popular_videos_with_public
+    popular_video_ids = popular_videos.where(is_public: true).ids
+    videos.where(id: popular_video_ids)
+  end
+
   def follow(other_user)
     following << other_user unless self == other_user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,13 +35,13 @@ class User < ApplicationRecord
   enum gender: { not_known: 0, male: 1, female: 2, not_applicabel: 9 }
 
   def subscription_channels_with_public
-    subscription_channel_ids = subscription_channels.where(is_public: true).ids
-    channels.where(id: subscription_channel_ids)
+    subscription_channels_channel_ids = subscription_channels.where(is_public: true).map(&:channel_id)
+    channels.where(id: subscription_channels_channel_ids)
   end
 
   def popular_videos_with_public
-    popular_video_ids = popular_videos.where(is_public: true).ids
-    videos.where(id: popular_video_ids)
+    popular_videos_video_ids = popular_videos.where(is_public: true).map(&:video_id)
+    videos.where(id: popular_videos_video_ids)
   end
 
   def follow(other_user)

--- a/app/views/channels/_channel.html.erb
+++ b/app/views/channels/_channel.html.erb
@@ -1,7 +1,7 @@
 <div class="col-md-6 channel-item">
   <%= link_to '#' do %>
     <%= image_tag channel.thumbnail_url, class: "img-circle", size: '50x50' if channel.thumbnail_url %>
-    <span class="channel-name"><%= channel.name %></span>
+    <span id="channel-name-<%= channel.id %>" class="channel-name"><%= channel.name %></span>
   <% end %>
   <div class="mt-30">
     <p>ジャンル</p>

--- a/app/views/contents/_content.html.erb
+++ b/app/views/contents/_content.html.erb
@@ -6,6 +6,6 @@
     <p>動画タイトル:節約のメリット10選</p>
     <p>チャンネル名：倹者の流儀</p>
     <p>評価：<%= content.decorate.rating(content.rating) %></p>
-    <p>感想：<%= content.feedback %></p>
+    <p id="content-feedback-<%= content.id %>">感想：<%= content.feedback %></p>
   </div>
 </div>

--- a/app/views/popular_videos/edit.html.erb
+++ b/app/views/popular_videos/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for(:title, t(".title")) %>
+<h1 class="text-center"><%= t(".title") %></h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(url: popular_videos_path, method: :patch) do |f| %>
+      <% @popular_videos.each do |popular_video| %>
+        <% video = Video.find(popular_video.video_id) %>
+        <div class="mt-30">
+          <h4 class="video-title"><%= "【#{video.title}】" %></h4>
+          <h4><%= "チャンネル名:『#{video.channel.name}』" %></h4>
+
+          <div>
+            <%= label_tag "is_public#{popular_video.id}" do %>
+              <%= check_box_tag "is_public#{popular_video.id}", true, false, checked: popular_video.is_public %>
+              <span>公開設定にする</span>
+            <% end %>
+          </div>
+        </div>
+
+        <hr>
+      <% end %>
+      <%= f.submit "設定する", class: "btn btn-primary btn-block mt-30" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/popular_videos/edit.html.erb
+++ b/app/views/popular_videos/edit.html.erb
@@ -3,6 +3,8 @@
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
+    <%= render 'shared/check_public', contents: "高評価動画" %>
+
     <%= form_with(url: popular_videos_path, method: :patch) do |f| %>
       <% @popular_videos.each do |popular_video| %>
         <% video = Video.find(popular_video.video_id) %>
@@ -12,7 +14,7 @@
 
           <div>
             <%= label_tag "is_public#{popular_video.id}" do %>
-              <%= check_box_tag "is_public#{popular_video.id}", true, false, checked: popular_video.is_public %>
+              <%= check_box_tag "is_public#{popular_video.id}", true, false, checked: popular_video.is_public, class: "is_public" %>
               <span>公開設定にする</span>
             <% end %>
           </div>

--- a/app/views/shared/_check_public.html.erb
+++ b/app/views/shared/_check_public.html.erb
@@ -1,0 +1,6 @@
+<div class="text-center mt-30">
+  <%= label_tag "is_public" do %>
+    <%= check_box_tag "is_public" %>
+    <span><%= "すべての#{contents}を公開設定にする" %></span>
+  <% end %>
+</div>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |message_type, message| %>
-  <% unless message_type == "user_params" %>
+  <% unless %w[user_name setting_public].any?(message_type) %>
     <div class="alert alert-<%= message_type %>">
       <%= message %>
     </div>

--- a/app/views/subscription_channels/edit.html.erb
+++ b/app/views/subscription_channels/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for(:title, t(".title")) %>
+<h1 class="text-center"><%= t(".title") %></h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(url: subscription_channels_path, method: :patch) do |f| %>
+      <% @subscription_channels.each do |subscription_channel| %>
+        <% channel = Channel.find(subscription_channel.channel_id) %>
+        <div class="mt-30">
+          <%= image_tag channel.thumbnail_url, class: "img-circle", size: '50x50' if channel.thumbnail_url %>
+          <span class="channel-name"><%= channel.name %></span>
+
+          <div>
+            <%= label_tag "is_public#{subscription_channel.id}" do %>
+              <%= check_box_tag "is_public#{subscription_channel.id}", true, false, checked: subscription_channel.is_public %>
+              <span>公開設定にする</span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+      <%= f.submit "設定する", class: "btn btn-primary btn-block mt-30" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/subscription_channels/edit.html.erb
+++ b/app/views/subscription_channels/edit.html.erb
@@ -18,6 +18,7 @@
           </div>
         </div>
       <% end %>
+      <%= hidden_field_tag 'setting_public', true if flash[:setting_public] %>
       <%= f.submit "設定する", class: "btn btn-primary btn-block mt-30" %>
     <% end %>
   </div>

--- a/app/views/subscription_channels/edit.html.erb
+++ b/app/views/subscription_channels/edit.html.erb
@@ -3,6 +3,8 @@
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
+    <%= render 'shared/check_public', contents: "登録チャンネル" %>
+
     <%= form_with(url: subscription_channels_path, method: :patch) do |f| %>
       <% @subscription_channels.each do |subscription_channel| %>
         <% channel = Channel.find(subscription_channel.channel_id) %>
@@ -12,11 +14,13 @@
 
           <div>
             <%= label_tag "is_public#{subscription_channel.id}" do %>
-              <%= check_box_tag "is_public#{subscription_channel.id}", true, false, checked: subscription_channel.is_public %>
+              <%= check_box_tag "is_public#{subscription_channel.id}", true, false, checked: subscription_channel.is_public, class: "is_public" %>
               <span>公開設定にする</span>
             <% end %>
           </div>
         </div>
+
+        <hr>
       <% end %>
       <%= hidden_field_tag 'setting_public', true if flash[:setting_public] %>
       <%= f.submit "設定する", class: "btn btn-primary btn-block mt-30" %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -2,7 +2,7 @@
   <div class="user-info">
     <%= link_to channels_user_path(user) do %>
       <%= image_tag(user.avatar_url, class: "img-circle", size: '50x50') %>
-      <span class="user-name"><%= user.name %></span>
+      <span id="user-name-<%= user.id %>" class="user-name"><%= user.name %></span>
     <% end %>
   </div>
   <div class="follow-btn">

--- a/app/views/users/channels.html.erb
+++ b/app/views/users/channels.html.erb
@@ -6,6 +6,7 @@
     <%= button_to "Googleログイン(登録チャンネル/高評価動画を同期)", "/auth/google_oauth2", method: :post, data: { turbo: false }, class: "btn btn-primary btn-block google-btn" if current_user?(@user) %>
     <%= render 'user_link' %>
 
+    <%= link_to "公開設定を変更する", edit_subscription_channels_path, class: "btn btn-primary btn-block mt-30" %>
     <%= render 'channels/user_channels' %>
   </div>
 </div>

--- a/app/views/users/videos.html.erb
+++ b/app/views/users/videos.html.erb
@@ -6,6 +6,7 @@
     <%= button_to "Googleログイン(登録チャンネル/高評価動画を同期)", "/auth/google_oauth2", method: :post, data: { turbo: false }, class: "btn btn-primary btn-block google-btn" if current_user?(@user) %>
     <%= render 'user_link' %>
 
+    <%= link_to "公開設定を変更する", edit_popular_videos_path, class: "btn btn-primary btn-block mt-30" %>
     <%= render 'videos/user_videos' %>
   </div>
 </div>

--- a/app/views/videos/_video.html.erb
+++ b/app/views/videos/_video.html.erb
@@ -3,7 +3,7 @@
     <iframe width="336" height="189" src=<%= "https://www.youtube.com/embed/#{video.video_id}" %> title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
   </div>
   <div class="col-md-7">
-    <h3 class="video-title"><%= video.title %></h3>
+    <h3 id="video-title-<%= video.id %>" class="video-title"><%= video.title %></h3>
     <p class="video-user"><%= "高評価しているユーザー数：#{number_with_delimiter(video.users.count, delimiter: ',')}人" %></p>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -48,6 +48,12 @@ ja:
     update:
       success: 公開設定を行いました
       danger: 設定に失敗しました
+  popular_videos:
+    edit:
+      title: 高評価動画の公開設定
+    update:
+      success: 公開設定を行いました
+      danger: 設定に失敗しました
   enums:
     user:
       gender:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -46,14 +46,14 @@ ja:
     edit:
       title: 登録チャンネルの公開設定
     update:
-      success: 公開設定を行いました
-      danger: 設定に失敗しました
+      success: 登録チャンネルの公開設定を行いました
+      danger: 登録チャンネルの公開設定に失敗しました
   popular_videos:
     edit:
       title: 高評価動画の公開設定
     update:
-      success: 公開設定を行いました
-      danger: 設定に失敗しました
+      success: 高評価動画の公開設定を行いました
+      danger: 高評価動画の公開設定に失敗しました
   enums:
     user:
       gender:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -42,6 +42,12 @@ ja:
     update:
       success: 好きな動画BEST3を更新しました
       danger: 好きな動画BEST3の更新に失敗しました
+  subscription_channels:
+    edit:
+      title: 登録チャンネルの公開設定
+    update:
+      success: 公開設定を行いました
+      danger: 設定に失敗しました
   enums:
     user:
       gender:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,5 @@ Rails.application.routes.draw do
   resources :relationships, only: %i[create destroy]
   resource :best_videos, only: %i[edit update]
   resource :best_channels, only: %i[edit update]
+  resource :subscription_channels, only: %i[edit update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,4 +22,5 @@ Rails.application.routes.draw do
   resource :best_videos, only: %i[edit update]
   resource :best_channels, only: %i[edit update]
   resource :subscription_channels, only: %i[edit update]
+  resource :popular_videos, only: %i[edit update]
 end

--- a/spec/system/user_contents_spec.rb
+++ b/spec/system/user_contents_spec.rb
@@ -2,28 +2,20 @@ require 'rails_helper'
 
 RSpec.describe "UserContents", type: :system do
   describe 'ユーザー詳細' do
-
-    before do
-      user = create(:user, password: 'password')
-      35.times do
-        channel = create(:channel)
-        user.add_subscription(channel)
-        video = create(:video)
-        user.add_popular_videos(video)
-        create(:content, user: user)
-        new_user = create(:user)
-        user.follow(new_user)
-        new_user.follow(user)
-      end
-    end
-
-    let(:user) { User.first }
+    let!(:user) { create(:user, password: 'password') }
 
     context 'ユーザーの登録チャンネル一覧を表示' do
+      before do
+        35.times do
+          channel = create(:channel)
+          user.subscription_channels.create(channel: channel, is_public: true)
+        end
+      end
+
       it 'ユーザーの登録チャンネル一覧が表示される' do
         visit channels_user_path(user)
         user.channels.page(1).each do |channel|
-          expect(page).to have_content channel.name
+          expect(page).to have_selector "#channel-name-#{channel.id}", text: channel.name
         end
         expect(page).to have_selector '.active', text: '登録チャンネル'
         expect(page).to have_title page_title("#{user.name}の登録チャンネル"), exact: true
@@ -31,10 +23,17 @@ RSpec.describe "UserContents", type: :system do
     end
 
     context 'ユーザーの高評価した動画一覧を表示' do
+      before do
+        35.times do
+          video = create(:video)
+          user.popular_videos.create(video: video, is_public: true)
+        end
+      end
+
       it 'ユーザーの高評価した動画一覧が表示される' do
         visit videos_user_path(user)
         user.videos.page(1).per(8).each do |video|
-          expect(page).to have_content video.title
+          expect(page).to have_selector "#video-title-#{video.id}", text: video.title
         end
         expect(page).to have_selector '.active', text: '高評価した動画'
         expect(page).to have_title page_title("#{user.name}の高評価動画"), exact: true
@@ -42,34 +41,45 @@ RSpec.describe "UserContents", type: :system do
     end
 
     context 'ユーザーの投稿一覧を表示' do
+      before do
+        35.times do
+          create(:content)
+        end
+      end
+
       it 'ユーザーの投稿一覧が表示される' do
         visit contents_user_path(user)
         user.contents.page(1).per(8).each do |content|
-          expect(page).to have_content "評価：#{"☆" * content.rating}"
-          expect(page).to have_content "感想：#{content.feedback}"
+          expect(page).to have_selector "#content-feedback-#{content.id}", text: "感想：#{content.feedback}"
         end
         expect(page).to have_selector '.active', text: '投稿'
         expect(page).to have_title page_title("#{user.name}のコンテンツ"), exact: true
       end
     end
 
-    context 'ユーザーのフォロー一覧を表示' do
+    context 'ユーザーのフォロー一覧 / フォロワー一覧を表示' do
+      before do
+        35.times do
+          new_user = create(:user)
+          user.active_relationships.create(followed_id: new_user.id)
+          new_user.active_relationships.create(followed_id: user.id)
+        end
+      end
+
       it 'フォローしているユーザー一覧が表示される' do
         visit following_user_path(user)
         user.following.page(1).each do |user|
-          expect(page).to have_content user.name
+          expect(page).to have_selector "#user-name-#{user.id}", text: user.name
         end
         expect(page).to have_selector '.active', text: 'フォロー'
         expect(page).to have_title page_title("#{user.name}のフォロー"), exact: true
       end
-    end
 
-    context 'ユーザーのフォロワー一覧を表示' do
       it 'フォローしているユーザー一覧が表示される' do
         visit follower_user_path(user)
         click_link 'フォロワー'
         user.followers.page(1).each do |user|
-          expect(page).to have_content user.name
+          expect(page).to have_selector "#user-name-#{user.id}", text: user.name
         end
         expect(page).to have_selector '.active', text: 'フォロワー'
         expect(page).to have_title page_title("#{user.name}のフォロワー"), exact: true

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
-  let(:user) { create(:user, password: 'password') }
+  let!(:user) { create(:user, password: 'password') }
   
   describe 'ログイン前' do
     describe 'アクセス権限の確認' do


### PR DESCRIPTION
## 変更の概要

* 高評価動画および登録チャンネルの公開設定を変更できるように実装を追加
* 公開設定をした動画やチャンネルのみ表示されるように変更
* Close #22 

## 変更内容

### 登録チャンネル一覧
[![Image from Gyazo](https://i.gyazo.com/9afe48e4457cb4ed8c9baa580aedf7e2.png)](https://gyazo.com/9afe48e4457cb4ed8c9baa580aedf7e2)
### 高評価動画一覧
[![Image from Gyazo](https://i.gyazo.com/bfc03292d8b6310933d729c22f434d15.jpg)](https://gyazo.com/bfc03292d8b6310933d729c22f434d15)
### 登録チャンネルの公開設定の編集画面
[![Image from Gyazo](https://i.gyazo.com/ba5325e4ccccd893089d7bfc61019178.png)](https://gyazo.com/ba5325e4ccccd893089d7bfc61019178)
### 高評価動画の公開設定の編集画面
[![Image from Gyazo](https://i.gyazo.com/0966e1bb14c127358ac772738d44a907.png)](https://gyazo.com/0966e1bb14c127358ac772738d44a907)