### PR TITLE
投稿のコメント(作成、編集、削除)

### DIFF
--- a/app/controllers/content_comments_controller.rb
+++ b/app/controllers/content_comments_controller.rb
@@ -1,0 +1,29 @@
+class ContentCommentsController < ApplicationController
+  before_action :require_login
+  before_action :set_content, only: %i[new create]
+
+  def new
+    @content_comment = current_user.content_comments.build
+  end
+
+  def create
+    raise
+  end
+
+  def edit
+  end
+
+  def update
+    raise
+  end
+
+  def destroy
+    raise
+  end
+
+  private
+
+  def set_content
+    @content = Content.find(params[:content_id])
+  end
+end

--- a/app/controllers/content_comments_controller.rb
+++ b/app/controllers/content_comments_controller.rb
@@ -17,8 +17,7 @@ class ContentCommentsController < ApplicationController
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
     if @content_comment.update(content_comment_params)
@@ -29,12 +28,10 @@ class ContentCommentsController < ApplicationController
   end
 
   def destroy
-    @content = @content_comment.content
-    @content_comments = @content.content_comments.includes(:user).page(params[:page])
     @content_comment.destroy!
     respond_to do |format|
-      format.html { redirect_to @content, success: t('.success'), status: :see_other }
-      # format.turbo_stream { flash.now[:success] = t('.success') }
+      format.html { redirect_to @content_comment.content, success: t('.success'), status: :see_other }
+      format.turbo_stream { flash.now[:success] = t('.success') }
     end
   end
 

--- a/app/controllers/content_comments_controller.rb
+++ b/app/controllers/content_comments_controller.rb
@@ -1,6 +1,7 @@
 class ContentCommentsController < ApplicationController
   before_action :require_login
   before_action :set_content, only: %i[new create]
+  before_action :set_content_comment, only: %i[edit update destroy]
 
   def new
     @content_comment = current_user.content_comments.build
@@ -20,7 +21,11 @@ class ContentCommentsController < ApplicationController
   end
 
   def update
-    raise
+    if @content_comment.update(content_comment_params)
+      redirect_to @content_comment.content, success: t('.success')
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy
@@ -35,5 +40,9 @@ class ContentCommentsController < ApplicationController
 
   def set_content
     @content = Content.find(params[:content_id])
+  end
+
+  def set_content_comment
+    @content_comment = current_user.content_comments.find(params[:id])
   end
 end

--- a/app/controllers/content_comments_controller.rb
+++ b/app/controllers/content_comments_controller.rb
@@ -29,7 +29,13 @@ class ContentCommentsController < ApplicationController
   end
 
   def destroy
-    raise
+    @content = @content_comment.content
+    @content_comments = @content.content_comments.includes(:user).page(params[:page])
+    @content_comment.destroy!
+    respond_to do |format|
+      format.html { redirect_to @content, success: t('.success'), status: :see_other }
+      # format.turbo_stream { flash.now[:success] = t('.success') }
+    end
   end
 
   private

--- a/app/controllers/content_comments_controller.rb
+++ b/app/controllers/content_comments_controller.rb
@@ -7,7 +7,13 @@ class ContentCommentsController < ApplicationController
   end
 
   def create
-    raise
+    @content_comment = current_user.content_comments.build(content_comment_params)
+
+    if @content_comment.save
+      redirect_to @content, success: t('.success')
+    else
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def edit
@@ -22,6 +28,10 @@ class ContentCommentsController < ApplicationController
   end
 
   private
+
+  def content_comment_params
+    params.require(:content_comment).permit(:body, :content_id)
+  end
 
   def set_content
     @content = Content.find(params[:content_id])

--- a/app/decorators/content_comment_decorator.rb
+++ b/app/decorators/content_comment_decorator.rb
@@ -1,0 +1,13 @@
+class ContentCommentDecorator < ApplicationDecorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/decorators/content_comment_decorator.rb
+++ b/app/decorators/content_comment_decorator.rb
@@ -9,5 +9,4 @@ class ContentCommentDecorator < ApplicationDecorator
   #       object.created_at.strftime("%a %m/%d/%y")
   #     end
   #   end
-
 end

--- a/app/views/content_comments/_content_comment.html.erb
+++ b/app/views/content_comments/_content_comment.html.erb
@@ -6,7 +6,7 @@
 </div>
 <p id="comment-body-<%= content_comment.id %>"><%= content_comment.body %></p>
 <% if current_user?(content_comment.user) %>
-  <%= link_to "編集", '#', class: "btn btn-primary" %>
+  <%= link_to "編集", edit_content_comment_path(content_comment), class: "btn btn-primary" %>
   <%= link_to "削除", '#', data: { "turbo-method": :delete, turbo_confirm: "コメントを削除してよろしいですか?" }, class: "btn btn-danger" %>
 <% end %>
 

--- a/app/views/content_comments/_content_comment.html.erb
+++ b/app/views/content_comments/_content_comment.html.erb
@@ -7,7 +7,7 @@
 <p id="comment-body-<%= content_comment.id %>"><%= content_comment.body %></p>
 <% if current_user?(content_comment.user) %>
   <%= link_to "編集", edit_content_comment_path(content_comment), class: "btn btn-primary" %>
-  <%= link_to "削除", '#', data: { "turbo-method": :delete, turbo_confirm: "コメントを削除してよろしいですか?" }, class: "btn btn-danger" %>
+  <%= link_to "削除", content_comment, data: { "turbo-method": :delete, turbo_confirm: "コメントを削除してよろしいですか?" }, class: "btn btn-danger" %>
 <% end %>
 
 <hr>

--- a/app/views/content_comments/_content_comment.html.erb
+++ b/app/views/content_comments/_content_comment.html.erb
@@ -1,13 +1,15 @@
-<div class="user-info">
-  <%= link_to channels_user_path(content_comment.user) do %>
-    <%= image_tag(content_comment.user.avatar_url, class: "img-circle", size: '50x50') %>
-    <span id="user-name-<%= content_comment.user.id %>" class="user-name"><%= content_comment.user.name %></span>
+<div id="content-comment-<%= content_comment.id %>">
+  <div class="user-info">
+    <%= link_to channels_user_path(content_comment.user) do %>
+      <%= image_tag(content_comment.user.avatar_url, class: "img-circle", size: '50x50') %>
+      <span id="user-name-<%= content_comment.user.id %>" class="user-name"><%= content_comment.user.name %></span>
+    <% end %>
+  </div>
+  <p id="comment-body-<%= content_comment.id %>"><%= content_comment.body %></p>
+  <% if current_user?(content_comment.user) %>
+    <%= link_to "編集", edit_content_comment_path(content_comment), class: "btn btn-primary" %>
+    <%= link_to "削除", content_comment, data: { "turbo-method": :delete, turbo_confirm: "コメントを削除してよろしいですか?" }, class: "btn btn-danger" %>
   <% end %>
-</div>
-<p id="comment-body-<%= content_comment.id %>"><%= content_comment.body %></p>
-<% if current_user?(content_comment.user) %>
-  <%= link_to "編集", edit_content_comment_path(content_comment), class: "btn btn-primary" %>
-  <%= link_to "削除", content_comment, data: { "turbo-method": :delete, turbo_confirm: "コメントを削除してよろしいですか?" }, class: "btn btn-danger" %>
-<% end %>
 
-<hr>
+  <hr>
+</div>

--- a/app/views/content_comments/destroy.turbo_stream.erb
+++ b/app/views/content_comments/destroy.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.remove "content-comment-#{@content_comment.id}" %>
+
+<%= turbo_stream.update "flash-message" do %>
+  <%= render 'shared/flash_message' %>
+<% end %>

--- a/app/views/content_comments/edit.html.erb
+++ b/app/views/content_comments/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>ContentComments#edit</h1>
+<p>Find me in app/views/content_comments/edit.html.erb</p>

--- a/app/views/content_comments/edit.html.erb
+++ b/app/views/content_comments/edit.html.erb
@@ -1,2 +1,16 @@
-<h1>ContentComments#edit</h1>
-<p>Find me in app/views/content_comments/edit.html.erb</p>
+<% content_for(:title, t(".title")) %>
+<h1 class="text-center"><%= t(".title") %></h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with model: @content_comment do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
+
+      <div class="form-group mt-30">
+        <%= f.text_area :body, size: "40x10", class: "form-control" %>
+      </div>
+
+      <%= f.submit "投稿する", class: "btn btn-primary btn-block mt-30" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/content_comments/new.html.erb
+++ b/app/views/content_comments/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for(:title, t(".title")) %>
+<h1 class="text-center"><%= t(".title") %></h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with model: @content_comment, url: content_content_comments_path(@content) do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
+
+      <%= f.hidden_field :content_id, value: @content.id %>
+
+      <div class="form-group mt-30">
+        <%= f.text_area :body, size: "40x10", class: "form-control" %>
+      </div>
+
+      <%= f.submit "投稿する", class: "btn btn-primary btn-block mt-30" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/contents/show.html.erb
+++ b/app/views/contents/show.html.erb
@@ -15,6 +15,9 @@
   </div>
 
   <div class="col-md-10 col-md-offset-1">
+    <div class="mt-30">
+      <%= link_to "コメントの新規作成", new_content_content_comment_path(@content), class: "btn btn-primary btn-block" if logged_in? %>
+    </div>
     <h2 class="text-center">コメント一覧</h2>
     <div class="text-center"><%= paginate @content_comments, theme: 'bootstrap-5' %></div>
     <%= render @content_comments %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -97,6 +97,17 @@ ja:
       success: 投稿の編集を行いました
     destroy:
       success: 投稿を削除しました
+  content_comments:
+    new:
+      title: 投稿へのコメントを作成
+    create:
+      success: 投稿へのコメントを作成しました
+    edit:
+      title: 投稿へのコメントを編集
+    update:
+      success: 投稿へのコメントを編集しました
+    destroy:
+      success: 投稿へのコメントを削除しました
   enums:
     user:
       gender:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,9 @@ Rails.application.routes.draw do
   resources :videos, only: %i[index show], shallow: true do
     resources :video_comments, only: %i[new create edit update destroy]
   end
-  resources :contents
+  resources :contents, shallow: true do
+    resources :content_comments, only: %i[new create edit update destroy]
+  end
   resource :best_videos, only: %i[edit update]
   resource :best_channels, only: %i[edit update]
   resource :subscription_channels, only: %i[edit update]


### PR DESCRIPTION
## 変更の概要

* 投稿に対するコメントの作成ページを実装
* 投稿に対するコメントの作成機能を実装
* 投稿に対するコメントの編集ページを実装
* 投稿に対するコメントの編集機能を実装
* 投稿に対するコメントの削除機能を実装
* 削除機能のAjax化
* Close #35 

## 変更内容

### 投稿へのコメント一覧
[![Image from Gyazo](https://i.gyazo.com/9468ea4c49b1c975d247a182a70d6ce8.jpg)](https://gyazo.com/9468ea4c49b1c975d247a182a70d6ce8)
### 投稿へのコメント作成ページ
[![Image from Gyazo](https://i.gyazo.com/377c8164762306288eba4f6174eba5ed.png)](https://gyazo.com/377c8164762306288eba4f6174eba5ed)
### 投稿へのコメント編集ページ
[![Image from Gyazo](https://i.gyazo.com/4ec9616b5a2b9c555f397bd20fd97e15.png)](https://gyazo.com/4ec9616b5a2b9c555f397bd20fd97e15)