### PR TITLE
曖昧検索を実行時、英文字が大文字/小文字で区別されないように変更

### DIFF
--- a/app/forms/search_channels_form.rb
+++ b/app/forms/search_channels_form.rb
@@ -9,9 +9,11 @@ class SearchChannelsForm
     relation = Channel.distinct.with_users
 
     names.each do |name|
+      name.downcase!
       relation = relation.name_contain(name)
     end
     description_words.each do |word|
+      word.downcase!
       relation = relation.description_contain(word)
     end
     relation

--- a/app/forms/search_users_form.rb
+++ b/app/forms/search_users_form.rb
@@ -14,6 +14,7 @@ class SearchUsersForm
     relation = relation.by_category(category_id) if category_title.present?
     relation = relation.by_channel(channel_id) if channel_id.present?
     names.each do |name|
+      name.downcase!
       relation = relation.name_contain(name)
     end
     relation

--- a/app/forms/search_videos_form.rb
+++ b/app/forms/search_videos_form.rb
@@ -10,6 +10,7 @@ class SearchVideosForm
 
     relation = relation.by_category(category_id) if category_title.present?
     description_words.each do |word|
+      word.downcase!
       relation = relation.description_contain(word)
     end
     relation

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -12,8 +12,8 @@ class Channel < ApplicationRecord
 
   scope :with_users, -> { joins(:subscription_channels).merge(where(subscription_channels: { channel_id: ids })) }
   scope :recent_and_with_users, -> { where('channels.created_at >= ?', 3.days.ago.beginning_of_day).joins(:users).group('channels.id').having('COUNT(users.id) > 0') }
-  scope :name_contain, ->(name) { where('name LIKE ?', "%#{name}%") }
-  scope :description_contain, ->(word) { where('description LIKE ?', "%#{word}%") }
+  scope :name_contain, ->(name) { where('LOWER(name) LIKE ?', "%#{name}%") }
+  scope :description_contain, ->(word) { where('LOWER(description) LIKE ?', "%#{word}%") }
 
   def users_with_public
     subscription_channels_user_ids = subscription_channels.where(is_public: true).map(&:user_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,7 +51,7 @@ class User < ApplicationRecord
   scope :by_age, ->(age) { where(age:) }
   scope :by_category, ->(category_id) { joins(:user_categories).merge(where(user_categories: { category_id: })) }
   scope :by_channel, ->(channel_id) { joins(:subscription_channels).merge(where(subscription_channels: { channel_id: })) }
-  scope :name_contain, ->(name) { where('name LIKE ?', "%#{name}%") }
+  scope :name_contain, ->(name) { where('LOWER(name) LIKE ?', "%#{name}%") }
 
   def subscription_channels_with_public
     subscription_channels_channel_ids = subscription_channels.where(is_public: true).map(&:channel_id)

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -15,7 +15,7 @@ class Video < ApplicationRecord
   scope :with_users, -> { joins(:popular_videos).merge(where(popular_videos: { video_id: ids })) }
   scope :recent_and_with_users, -> { where('videos.created_at >= ?', 3.days.ago.beginning_of_day).joins(:users).group('videos.id').having('COUNT(users.id) > 0') }
   scope :by_category, ->(category_id) { where(category_id:) }
-  scope :description_contain, ->(word) { where('description LIKE ?', "%#{word}%") }
+  scope :description_contain, ->(word) { where('LOWER(description) LIKE ?', "%#{word}%") }
 
   def users_with_public
     popular_videos_user_ids = popular_videos.where(is_public: true).map(&:user_id)


### PR DESCRIPTION
## 変更の概要

* 曖昧検索を行う前に「検索ワード」と「DBに保存されたデータ」を小文字にして検索を行うように実装
* Close #140 

## なぜこの変更をするのか

* 本番環境でチャンネル名やユーザー名を検索した際、大文字/小文字が区別され検索にヒットしない不具合が発生
* ローカル環境と本番環境で違うデータベースを使用しているのが原因