### PR TITLE
ユーザーの削除機能を実装

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -49,7 +49,9 @@ header {
     padding: 15px 30px;
     height: 50px;
   }
-  
+  #dropdown {
+    position: static;
+  }
 }
 
 .sidebar {
@@ -593,9 +595,11 @@ footer {
 /* JavaScript */
 
 .dropdown-menu.active {
+  text-align: center;
   display: block;
   position: absolute;
-  left: -90px;
+  left: auto;
+  right: 0;
 }
 
 /* Google API サービスポリシーへのリンク */
@@ -749,6 +753,9 @@ footer {
       box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
       border-radius: 8px;
       float: right;
+      a {
+        color: black;
+      }
     }
     a {
       text-align: center;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,6 +39,11 @@ class UsersController < ApplicationController
     end
   end
 
+  def destroy
+    User.find(params[:id]).destroy!
+    redirect_to root_url, status: :see_other, success: t('.success')
+  end
+
   def confirm
     params[:user] = flash[:user_params]
     return redirect_to root_url if params[:user].nil?

--- a/app/javascript/custom/menu.js
+++ b/app/javascript/custom/menu.js
@@ -18,15 +18,13 @@ document.addEventListener("turbo:load", function() {
   if (hamburger !== null) {
     hamburger.addEventListener("click", function(event) {
       event.preventDefault();
-
       const navbarMenu = document.querySelector("#navbar-menu");
-      const is_menu_visible = navbarMenu.classList.contains("in");
-
-      if (is_menu_visible) {
-        navbarMenu.classList.remove("in");
-      } else {
-        navbarMenu.classList.add("in");
-      }
+      navbarMenu.classList.toggle("in");
+      document.addEventListener("click", function(event) {
+        if(event.target.closest('header') === null) {
+          navbarMenu.classList.remove("in");
+        }
+      });
     });
   }
 });

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,6 @@ class User < ApplicationRecord
   before_save :downcase_email
 
   has_many :contents
-  has_many :microposts, dependent: :destroy
   has_many :active_relationships,  class_name: 'Relationship', foreign_key: 'follower_id', dependent: :destroy
   has_many :passive_relationships, class_name: 'Relationship', foreign_key: 'followed_id', dependent: :destroy
   has_many :following, through: :active_relationships,  source: :followed

--- a/app/views/users/_user_profile.html.erb
+++ b/app/views/users/_user_profile.html.erb
@@ -20,6 +20,7 @@
             <%= link_to "プロフィールを編集", edit_user_path(current_user), class: "btn btn-default btn-block" %>
             <%= link_to "好きなチャンネルの編集", edit_best_channels_path, id: "edit-best-channels", class: "btn btn-default btn-block" %>
             <%= link_to "好きな動画の編集", edit_best_videos_path, id: "edit-best-videos", class: "btn btn-default btn-block hidden" %>
+            <%= link_to "ユーザーの削除", '#', data: { "turbo-method": :delete, turbo_confirm: "ユーザーの削除を行います。投稿やユーザープロフィールといったすべてのデータが削除されます。よろしいですか？" }, class: "btn btn-danger btn-block" %>
           <% end %>
         </div>
       </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -15,6 +15,8 @@ ja:
       title: ユーザー編集
     update:
       success: ユーザー情報を編集しました
+    destroy:
+      success: ユーザーを削除しました
     confirm:
       title: ユーザー登録(確認画面)
     signup_check:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get 'auth/:provider/callback', to: 'google_login_api#callback'
   get 'auth/failure', to: redirect('/')
 
-  resources :users, only: %i[index show create edit update] do
+  resources :users do
     get :confirm, on: :collection
     member do
       get :edit_best, :channels, :videos, :playlists, :contents, :following, :follower


### PR DESCRIPTION
## 変更の概要

* プロフィールページにユーザーの削除ボタンを実装
* ドロップダウンメニューのUIを修正
* ログイン前のドロップ画面で関係ない場所をタッチした際にメニューが消えるように改善
* Close #144 

## なぜこの変更をするのか

* ユーザーが自分自身のアカウントを削除することができなかったため
* ユーザー名の長さによって、ドロップダウンメニューのUIが崩れてしまっていたため