### PR TITLE
パスワードリセット機能が利用できないようにリンクとルーティングを削除

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -11,7 +11,6 @@
 
       <div class="form-group mt-30">
         <%= f.label :password, "パスワード", class: "form-label" %>
-        <%= link_to "(パスワードをお忘れの方はこちら)", new_password_reset_path %>
         <%= f.password_field :password, class: "form-control", placeholder: "パスワードを入力してください" %>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,10 @@ Rails.application.routes.draw do
       get :edit_best, :channels, :videos, :playlists, :contents, :following, :follower
     end
   end
-  resources :password_resets, only: %i[new create edit update]
+
+  # 本番環境でメールサーバーの契約予定がないため削除
+  # resources :password_resets, only: %i[new create edit update]
+  
   resources :relationships, only: %i[create destroy]
   resources :channels, only: %i[index show], shallow: true do
     resources :channel_comments, only: %i[new create edit update destroy]


### PR DESCRIPTION
## 変更の概要

* ログイン画面からパスワードリセット画面へのリンクを削除
* パスワードリセット関連のルーティングを削除
* Close #147 

## なぜこの変更をするのか

* 本番環境でメールサーバーの契約予定がないため
* 契約した場合は使えるように実装したコードは残しておいた