### PR TITLE
ログイン後に高評価動画一覧ページにリダイレクト

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,7 +7,7 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password], params[:remember_me])
 
     if @user
-      redirect_to root_path, success: t('.success')
+      redirect_to videos_url, success: t('.success')
     else
       flash.now[:danger] = t('.danger')
       render :new, status: :unprocessable_entity


### PR DESCRIPTION
## 変更の概要

* ログインを行った後、高評価動画一覧が表示されるように変更
* Close #151 

## なぜこの変更をするのか

* ログイン後にメインコンテンツにリダイレクトされることで、ユーザビリティを向上