### PR TITLE
一覧メニューの優先度を変更(ユーザー一覧が一番下に表示される)

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -19,11 +19,11 @@
         <div class="col-md-3 col-xs-6">
           <p>一覧ページ</p>
           <ul class="nav nav nav-pills nav-stacked">
-            <li><%= link_to "- ユーザー一覧", users_path %></li>
-            <li><%= link_to "- チャンネル一覧", channels_path %></li>
             <li><%= link_to "- 高評価動画一覧", videos_path %></li>
+            <li><%= link_to "- チャンネル一覧", channels_path %></li>
             <li><%= link_to "- 投稿一覧", contents_path %></li>
             <li><%= link_to "- 新着コンテンツ一覧", recent_content_path %></li>
+            <li><%= link_to "- ユーザー一覧", users_path %></li>
           </ul>
         </div>
         <div class="col-md-3 pc">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,10 +6,10 @@
 
 <div class="smart-phone">
   <div class="site-link">
-    <div><%= link_to "ユーザー一覧", users_path, class: "#{"active" if current_page?(users_path)}" %></div>
-    <div><%= link_to "チャンネル一覧", channels_path, class: "#{"active" if current_page?(channels_path)}" %></div>
     <div><%= link_to "高評価動画一覧", videos_path, class: "#{"active" if current_page?(videos_path)}" %></div>
+    <div><%= link_to "チャンネル一覧", channels_path, class: "#{"active" if current_page?(channels_path)}" %></div>
     <div><%= link_to "投稿一覧", contents_path, class: "#{"active" if current_page?(contents_path)}" %></div>
     <div><%= link_to "新着コンテンツ一覧", recent_content_path, class: "#{"active" if current_page?(recent_content_path)}" %></div> 
+    <div><%= link_to "ユーザー一覧", users_path, class: "#{"active" if current_page?(users_path)}" %></div>
   </div>
 </div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -2,11 +2,11 @@
   <div class="sidebar text-center">
     <nav class="navbar navbar-default">
       <ul class="nav nav-pills nav-stacked">
-        <li role="presentation"><%= link_to "ユーザー一覧", users_path %></li>
-        <li role="presentation"><%= link_to "チャンネル一覧", channels_path %></li>
         <li role="presentation"><%= link_to "高評価動画一覧", videos_path %></li>
+        <li role="presentation"><%= link_to "チャンネル一覧", channels_path %></li>
         <li role="presentation"><%= link_to "投稿一覧", contents_path %></li>
         <li role="presentation"><%= link_to "新着コンテンツ一覧", recent_content_path %></li>
+        <li role="presentation"><%= link_to "ユーザー一覧", users_path %></li>
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
## 変更の概要

* サイドバー / スマホ画面のヘッダー / フッターの一覧の順序を変更
* Close #149

## なぜこの変更をするのか

* 「動画一覧」や「チャンネル一覧」をサービスのメインコンテンツとして使いやすくするため