### PR TITLE
Youtube Data APIのリクエスト数が1日の制限を超えないように最大数を制限

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -20,6 +20,7 @@ class Channel < ApplicationRecord
   scope :by_users_generation, ->(users_generation) { joins(:users).where('age BETWEEN ? AND ?', users_generation, users_generation + 9) }
 
   scope :user_count_order, -> { joins(:users).select('channels.*, COUNT(users.id) as user_count').group('channels.id').order('user_count DESC, channels.created_at DESC') }
+  scope :with_users_and_playlist_count_order, -> { joins(:subscription_channels).joins(:channel_playlists).where(subscription_channels: { channel_id: ids }).select('channels.*, COUNT(channel_playlists.id) as playlist_count').group('channels.id').order('playlist_count ASC').limit(50) }
 
   def users_with_public
     subscription_channels_user_ids = subscription_channels.where(is_public: true).map(&:user_id)

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -30,7 +30,7 @@ class Channel < ApplicationRecord
     def create_subscription_channel_list(access_token)
       channel_list = []
       GOOGLE_API_SERVICE.authorization = Signet::OAuth2::Client.new(access_token:)
-      subscriptions = GOOGLE_API_SERVICE.list_subscriptions(:snippet, mine: true, max_results: 50)
+      subscriptions = GOOGLE_API_SERVICE.list_subscriptions(:snippet, mine: true, max_results: 30)
       subscriptions.items.each do |item|
         channel_id = item.snippet.resource_id.channel_id
         channel_list << find_or_create_channel_by_channel_id(channel_id)
@@ -49,7 +49,7 @@ class Channel < ApplicationRecord
 
     def channel_params_by_channel_id(channel_id)
       GOOGLE_API_SERVICE.key = Settings.google_api_key
-      channel_info = GOOGLE_API_SERVICE.list_channels('snippet,statistics', id: channel_id).items[0]
+      channel_info = GOOGLE_API_SERVICE.list_channels('snippet,statistics', id: channel_id, max_results: 1).items[0]
       {
         channel_id:,
         thumbnail_url: channel_info.snippet.thumbnails.medium.url,
@@ -62,7 +62,7 @@ class Channel < ApplicationRecord
 
   def create_playlist
     GOOGLE_API_SERVICE.key = Settings.google_api_key
-    playlists = GOOGLE_API_SERVICE.list_playlists(:snippet, channel_id:, max_results: 50)
+    playlists = GOOGLE_API_SERVICE.list_playlists(:snippet, channel_id:, max_results: 10)
     return if playlists.items.empty?
 
     playlists.items.each do |playlist_item|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -156,7 +156,7 @@ class User < ApplicationRecord
 
   def create_playlist(access_token)
     GOOGLE_API_SERVICE.authorization = Signet::OAuth2::Client.new(access_token:)
-    playlists = GOOGLE_API_SERVICE.list_playlists(:snippet, mine: true, max_results: 50)
+    playlists = GOOGLE_API_SERVICE.list_playlists(:snippet, mine: true, max_results: 10)
     return if playlists.items.empty?
 
     playlists.items.each do |playlist_item|

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -31,7 +31,7 @@ class Video < ApplicationRecord
     def create_popular_video_list(access_token)
       video_list = []
       GOOGLE_API_SERVICE.authorization = Signet::OAuth2::Client.new(access_token:)
-      videos = GOOGLE_API_SERVICE.list_videos(:snippet, my_rating: 'like', max_results: 50)
+      videos = GOOGLE_API_SERVICE.list_videos(:snippet, my_rating: 'like', max_results: 30)
       videos.items.each do |video|
         video_list << find_or_create_video_by_video(video)
       end
@@ -41,9 +41,9 @@ class Video < ApplicationRecord
     def find_or_create_videos_by_playlist_id(playlist_id)
       videos = []
       GOOGLE_API_SERVICE.key = Settings.google_api_key
-      playlist_items = GOOGLE_API_SERVICE.list_playlist_items(:snippet, playlist_id:)
-      playlist_items.items.each do |playlist_item|
-        video_id = playlist_item.snippet.resource_id.video_id
+      playlist_videos = GOOGLE_API_SERVICE.list_playlist_items(:snippet, playlist_id:, max_results: 5)
+      playlist_videos.items.each do |playlist_video|
+        video_id = playlist_video.snippet.resource_id.video_id
         video = find_or_create_video_by_video_id(video_id)
         videos << video if video
       end
@@ -52,7 +52,7 @@ class Video < ApplicationRecord
 
     def find_or_create_video_by_video_id(video_id)
       GOOGLE_API_SERVICE.key = Settings.google_api_key
-      video = GOOGLE_API_SERVICE.list_videos(:snippet, id: video_id).items.first
+      video = GOOGLE_API_SERVICE.list_videos(:snippet, id: video_id, max_results: 1).items.first
 
       return nil unless video.present?
 

--- a/lib/tasks/youtube_data_api.rake
+++ b/lib/tasks/youtube_data_api.rake
@@ -1,7 +1,7 @@
 namespace :youtube_data_api do
   desc 'チャンネルのplaylistを取得する'
   task install_channel_playlists: :environment do
-    subscription_channels = Channel.distinct.with_users
+    subscription_channels = Channel.with_users_and_playlist_count_order
     subscription_channels.each(&:create_playlist)
   end
 end


### PR DESCRIPTION
## 変更の概要

* Youtube Data APIでリクエストを送る際のレスポンス数を制限
* バッチ処理でプレイリストを取得するチャンネルの数を最大50個に制限
* Close #166 

## なぜこの変更をするのか

* Youtube Data APIの1日あたりのリクエスト数の制限を超えてしまっていた
* ユーザー同期時のリクエスト内容も考慮し、最大数を制限