### PR TITLE
ユーザーモデルのテスト項目について整理

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ApplicationRecord
   has_many :categories, through: :user_categories, source: :category
   has_many :user_playlists, dependent: :destroy
 
-  validates :password, presence: true, length: { minimum: 8 }, if: -> { new_record? || changes[:crypted_password] }
+  validates :password, presence: true, length: { minimum: 8, maximum: 16 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :name, presence: true, length: { maximum: 50 }
@@ -41,6 +41,7 @@ class User < ApplicationRecord
   validates :age, allow_nil: true, numericality: { only_integer: true, in: 13..100 }
   validates :gender, presence: true
   validates :profile, length: { maximum: 400 }
+  validates :role, presence: true
   validates :reset_password_token, uniqueness: true, allow_nil: true
   validates :remember_me_token, uniqueness: true, allow_nil: true
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     password { password }
     password_confirmation { password }
     age { 20 }
-    gender { 1 }
     profile { "私はテスト用のユーザーです。よろしくお願いします。" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  let(:user) { create(:user) }
-  let(:best_channel) { create(:best_channel, rank: 1) }
-  let(:best_video) { create(:best_video, rank: 1) }
-
   describe "バリデーションチェック" do
     it "設定したすべてのバリデーションが機能しているか" do
       user = build(:user)
@@ -12,38 +8,31 @@ RSpec.describe User, type: :model do
       expect(user.errors).to be_empty
     end
 
-    it "nameがない場合にバリデーションが機能してinvalidになるか" do
+    it "ユーザー名がない場合にバリデーションが機能してinvalidになるか" do
       user_without_name = build(:user, name: "")
       expect(user_without_name).to be_invalid
       expect(user_without_name.errors.full_messages).to include "ユーザー名を入力してください"
     end
 
-    it "nameが51文字以上の場合にvalidationが機能してinvalidになるか" do
+    it "ユーザー名が51文字以上の場合にvalidationが機能してinvalidになるか" do
       user_with_long_name = build(:user, name: "a" * 51)
       expect(user_with_long_name).to be_invalid
       expect(user_with_long_name.errors.full_messages).to include "ユーザー名は50文字以内で入力してください"
     end
 
-    it "emailがない場合にバリデーションが機能してinvalidになるか" do
+    it "メールアドレスがない場合にバリデーションが機能してinvalidになるか" do
       user_without_email = build(:user, email: "")
       expect(user_without_email).to be_invalid
       expect(user_without_email.errors.full_messages).to include "メールアドレスを入力してください"
     end
 
-    it "emailがすでに登録されている場合にvalidationが機能してinvalidになるか" do
-      user = create(:user)
-      duplicate_user = user.dup
-      expect(duplicate_user).to be_invalid
-      expect(duplicate_user.errors.full_messages).to include "メールアドレスはすでに存在します"
-    end
-
-    it "emailが256文字以上の場合にvalidationが機能してinvalidになるか" do
+    it "メールアドレスが256文字以上の場合にvalidationが機能してinvalidになるか" do
       user_with_long_email = build(:user, email: "a" * 244 + "@example.com")
       expect(user_with_long_email).to be_invalid
       expect(user_with_long_email.errors.full_messages).to include "メールアドレスは255文字以内で入力してください"
     end
 
-    it "emailのフォーマットが不正な場合にvalidationが機能してinvalidになるか" do
+    it "メールアドレスのフォーマットが不正な場合にvalidationが機能してinvalidになるか" do
       invalid_addresses = %w[user@example,com user_at_foo.org user.name@example. foo@bar_baz.com foo@bar+baz.com foo@bar..com]
       invalid_addresses.each do |invalid_address|
         user_with_invalid_email = build(:user, email: invalid_address)
@@ -52,28 +41,42 @@ RSpec.describe User, type: :model do
       end
     end
 
-    it "passwordがない場合にvalidationが機能してinvalidになるか" do
+    it "メールアドレスがすでに登録されている場合にvalidationが機能してinvalidになるか" do
+      user = create(:user)
+      duplicate_user = user.dup
+      expect(duplicate_user).to be_invalid
+      expect(duplicate_user.errors.full_messages).to include "メールアドレスはすでに存在します"
+    end
+
+    it "パスワードがない場合にvalidationが機能してinvalidになるか" do
       blank_password = ""
       user_without_password = build(:user, password: blank_password, password_confirmation: blank_password)
       expect(user_without_password).to be_invalid
       expect(user_without_password.errors.full_messages).to include "パスワードを入力してください"
     end
 
-    it "passwordが8文字未満の場合にvalidationが機能してinvalidになるか" do
+    it "パスワードが8文字未満の場合にvalidationが機能してinvalidになるか" do
       seven_characters = "a" * 7
       user_with_short_password = build(:user, password: seven_characters, password_confirmation: seven_characters)
       expect(user_with_short_password).to be_invalid
       expect(user_with_short_password.errors.full_messages).to include "パスワードは8文字以上で入力してください"
     end
 
-    it "passwordとpassword_confirmationが異なる場合にvalidationが機能してinvalidになるか" do
+    it "パスワードが17文字以上の場合にvalidationが機能してinvalidになるか" do
+      seventeen_characters = "a" * 17
+      user_with_long_password = build(:user, password: seventeen_characters, password_confirmation: seventeen_characters)
+      expect(user_with_long_password).to be_invalid
+      expect(user_with_long_password.errors.full_messages).to include "パスワードは16文字以内で入力してください"
+    end
+
+    it "パスワードと確認用パスワードが異なる場合にvalidationが機能してinvalidになるか" do
       invalid_password = "invalid_password"
       user_with_invalid_confirmation_password = build(:user, password_confirmation: invalid_password)
       expect(user_with_invalid_confirmation_password).to be_invalid
       expect(user_with_invalid_confirmation_password.errors.full_messages).to include "確認用パスワードとパスワードの入力が一致しません"
     end
 
-    it "ageが13〜100以外の場合にvalidationが機能してinvalidになるか" do
+    it "年齢が13〜100以外の場合にvalidationが機能してinvalidになるか" do
       invalid_ages = [-1, 0, 12, 101, 150, 200]
       invalid_ages.each do |invalid_age|
         user_with_invalid_age = build(:user, age: invalid_age)
@@ -82,65 +85,42 @@ RSpec.describe User, type: :model do
       end
     end
 
-    it "genderがない場合にvalidationが機能してinvalidになるか" do
+    it "性別の入力がない場合にvalidationが機能してinvalidになるか" do
       user_without_gender = build(:user, gender: nil)
       expect(user_without_gender).to be_invalid
       expect(user_without_gender.errors.full_messages).to include "性別を入力してください"
     end
 
-    it "profileが400文字よりも多い場合にvalidationが機能してinvalidになるか" do
+    it "プロフィールが400文字よりも多い場合にvalidationが機能してinvalidになるか" do
       too_long_profile = "a" * 401
       user_with_long_profile = build(:user, profile: too_long_profile)
       expect(user_with_long_profile).to be_invalid
       expect(user_with_long_profile.errors.full_messages).to include "プロフィールは400文字以内で入力してください"
     end
+
+    it "権限の入力がない場合にvalidationが機能してinvalidになるか" do
+      user_without_role = build(:user, role: nil)
+      expect(user_without_role).to be_invalid
+    end
   end
 
-  describe "モデルに登録されているメソッドのチェック" do
-    it "emailが登録される場合に小文字に変換されているか" do
-      mixed_case_email = "Foo@ExAMPle.CoM"
-      user = create(:user, email: mixed_case_email)
-      expect(user.email).to eq mixed_case_email.downcase
+  describe "デフォルト値の確認" do
+    let(:user) { build(:user) }
+
+    it "性別のデフォルト値が0(回答なし)になっているか" do
+      expect(user.gender_i18n).to eq "回答なし"
     end
 
-    it "like_best_channelメソッドを実行した場合にいいね数が増えるか" do
-      before_count = user.like_best_channels.size
-      user.like_best_channel(best_channel)
-      expect(user.like_best_channels.size).to eq before_count + 1
+    it "権限のデフォルト値が1(一般)になっているか" do
+      expect(user.role_i18n).to eq "一般"
     end
 
-    it "dislike_best_channelメソッドを実行した場合にいいね数が減るか" do
-      user.like_best_channel(best_channel)
-      before_count = user.like_best_channels.size
-      user.dislike_best_channel(best_channel)
-      expect(user.like_best_channels.size).to eq before_count - 1
+    it "年齢の公開設定のデフォルト値がfalseになっているか" do
+      expect(user.age_is_public).to be_falsey
     end
 
-    it "like_best_channel?メソッドが機能していいね状態を確認できるか" do
-      user.like_best_channel(best_channel)
-      expect(user.like_best_channel?(best_channel)).to be_truthy
-      user.dislike_best_channel(best_channel)
-      expect(user.like_best_channel?(best_channel)).to be_falsey
-    end
-
-    it "like_best_videoメソッドを実行した場合にいいね数が増えるか" do
-      before_count = user.like_best_videos.size
-      user.like_best_video(best_video)
-      expect(user.like_best_videos.size).to eq before_count + 1
-    end
-
-    it "dislike_best_videoメソッドを実行した場合にいいね数が減るか" do
-      user.like_best_video(best_video)
-      before_count = user.like_best_videos.size
-      user.dislike_best_video(best_video)
-      expect(user.like_best_videos.size).to eq before_count - 1
-    end
-
-    it "like_best_video?メソッドが機能していいね状態を確認できるか" do
-      user.like_best_video(best_video)
-      expect(user.like_best_video?(best_video)).to be_truthy
-      user.dislike_best_video(best_video)
-      expect(user.like_best_video?(best_video)).to be_falsey
+    it "性別の公開設定のデフォルト値がfalseになっているか" do
+      expect(user.gender_is_public).to be_falsey
     end
   end
 
@@ -159,6 +139,14 @@ RSpec.describe User, type: :model do
         user = create(:user, role: key.to_i)
         expect(user.role_i18n).to eq value
       end
+    end
+  end
+
+  describe "コールバックが正しく機能しているか" do
+    it "メールアドレスが登録される場合に小文字に変換されているか" do
+      mixed_case_email = "Foo@ExAMPle.CoM"
+      user = create(:user, email: mixed_case_email)
+      expect(user.email).to eq mixed_case_email.downcase
     end
   end
 end


### PR DESCRIPTION
## 変更の概要

* ユーザーモデルのテスト項目について必要な項目を洗い出し、最低限のテストを実装
* Close #182

## テスト項目

### バリデーションチェック
- [x] ユーザー名(必須)
- [x] ユーザー名(50文字以内)
- [x] メールアドレス(必須)
- [x] メールアドレス(255文字以内)
- [x] メールアドレス(形式チェック)
- [x] メールアドレス(重複不可)
- [x] パスワード(必須)
- [x] パスワード(8文字以上)
- [x] パスワード(16文字以内)
- [x] パスワード(確認用パスワードと一致している)
- [x] 年齢(13〜100の整数のみ)
- [x] 性別(必須)
- [x] プロフィール(400字以内)
- [x] 権限(必須)
### デフォルト値の確認
- [x] 性別(デフォルト値：回答なし)
- [x] 権限(デフォルト値：一般)
- [x] 年齢の公開設定(デフォルト値：false)
- [x] 性別の公開設定(デフォルト値：false)
### enumの確認
- [x] 性別のenum(日本語が正しく表示される)
- [x] 年齢のenum(日本語が正しく表示される)
### コールバックの確認
- [x] メールアドレス(DBには全て小文字で保存される)