### PR TITLE
ユーザープレイリストモデルのテスト

### DIFF
--- a/app/models/user_playlist.rb
+++ b/app/models/user_playlist.rb
@@ -5,4 +5,5 @@ class UserPlaylist < ApplicationRecord
   has_many :videos, through: :user_playlist_videos, source: :video
 
   validates :playlist_id, presence: true, uniqueness: true
+  validates :title, presence: true
 end

--- a/spec/factories/user_playlists.rb
+++ b/spec/factories/user_playlists.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     playlist_id { "test_id" }
     title { "test_title" }
     description { "これはテスト用のプレイリストです" }
-    is_public { false }
     association :user
   end
 end

--- a/spec/models/user_playlist_spec.rb
+++ b/spec/models/user_playlist_spec.rb
@@ -8,17 +8,37 @@ RSpec.describe UserPlaylist, type: :model do
       expect(playlist.errors).to be_empty
     end
 
-    it "playlist_idがない場合にバリデーションが機能してinvalidになるか" do
+    it "プレイリストIDがない場合にバリデーションが機能してinvalidになるか" do
       playlist_without_playlist_id = build(:user_playlist, playlist_id: "")
       expect(playlist_without_playlist_id).to be_invalid
       expect(playlist_without_playlist_id.errors).to_not be_empty
     end
 
-    it "playlist_idがすでに登録されている場合にvalidationが機能してinvalidになるか" do
+    it "プレイリストIDがすでに登録されている場合にvalidationが機能してinvalidになるか" do
       playlist = create(:user_playlist)
       duplicate_playlist = playlist.dup
       expect(duplicate_playlist).to be_invalid
       expect(duplicate_playlist.errors).to_not be_empty
+    end
+
+    it "ユーザーIDがすでに登録されている場合にvalidationが機能してinvalidになるか" do
+      playlist_without_user_id = build(:user_playlist, user: nil)
+      expect(playlist_without_user_id).to be_invalid
+      expect(playlist_without_user_id.errors).to_not be_empty
+    end
+
+    it "タイトルがない場合にバリデーションが機能してinvalidになるか" do
+      playlist_without_title = build(:user_playlist, title: "")
+      expect(playlist_without_title).to be_invalid
+      expect(playlist_without_title.errors).to_not be_empty
+    end
+  end
+
+  describe "デフォルト値の確認" do
+    let(:playlist) { build(:user_playlist) }
+
+    it "公開設定のデフォルト値がfalseになっているか" do
+      expect(playlist.is_public).to be_falsey
     end
   end
 end


### PR DESCRIPTION
## 変更の概要

* ユーザープレイリストモデルのテスト項目作成&実装
* Close #187 

## テスト項目

### バリデーションチェック
- [x] プレイリストID(必須)
- [x] プレイリストID(重複禁止)
- [x] ユーザーID(必須)
- [x] タイトル(必須)

### デフォルト値の確認
- [x] 公開設定(デフォルト値：false)