### PR TITLE
SubscriptionChannelモデルのテスト

### DIFF
--- a/app/models/subscription_channel.rb
+++ b/app/models/subscription_channel.rb
@@ -1,4 +1,6 @@
 class SubscriptionChannel < ApplicationRecord
   belongs_to :user
   belongs_to :channel
+
+  validates :channel_id, uniqueness: { scope: :user_id }
 end

--- a/spec/factories/subscription_channels.rb
+++ b/spec/factories/subscription_channels.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :subscription_channel do
+    association :user
+    association :channel
+  end
+end

--- a/spec/models/subscription_channel_spec.rb
+++ b/spec/models/subscription_channel_spec.rb
@@ -1,26 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe SubscriptionChannel, type: :model do
-  let(:user) { create(:user) }
-  let(:channel) { create(:channel) }
-
   describe 'バリデーションチェック' do    
     it '設定したすべてのバリデーションが機能しているか' do
-      subscription_channel = user.subscription_channels.build(channel: channel)
+      subscription_channel = build(:subscription_channel)
       expect(subscription_channel).to be_valid
       expect(subscription_channel.errors).to be_empty
     end
 
-    it 'channel_idがない場合にバリデーションが機能してinvalidになるか' do
-      subscription_channel_without_channel_id = user.subscription_channels.build(channel: nil)
+    it 'チャンネルIDがない場合にバリデーションが機能してinvalidになるか' do
+      subscription_channel_without_channel_id = build(:subscription_channel, channel: nil)
       expect(subscription_channel_without_channel_id).to be_invalid
       expect(subscription_channel_without_channel_id.errors).to_not be_empty
     end
 
-    it 'user_idがない場合にバリデーションが機能してinvalidになるか' do
-      subscription_channel_without_user_id = SubscriptionChannel.new(user: nil, channel: channel)
+    it 'ユーザーIDがない場合にバリデーションが機能してinvalidになるか' do
+      subscription_channel_without_user_id = build(:subscription_channel, user: nil)
       expect(subscription_channel_without_user_id).to be_invalid
       expect(subscription_channel_without_user_id.errors).to_not be_empty
+    end
+
+    it 'チャンネルIDとユーザーIDの組み合わせが既に存在している場合にバリデーションが機能してinvalidになるか' do
+      subscription_channel = create(:subscription_channel)
+      duplicate_subscription_channel = subscription_channel.dup
+      expect(duplicate_subscription_channel).to be_invalid
+      expect(duplicate_subscription_channel.errors).to_not be_empty
+    end
+  end
+
+  describe 'デフォルト値の確認' do
+    let(:subscription_channel) { build(:subscription_channel) }
+
+    it '公開設定のデフォルト値がfalse(非公開)になっているか' do
+      expect(subscription_channel.is_public).to be_falsey
     end
   end
 end


### PR DESCRIPTION
## 変更の概要

* SubscriptionChannelモデルのテスト項目作成&テスト実装
* Close #207 

## テスト項目

### バリデーションチェック
- [x] チャンネルID(必須)
- [x] ユーザーID(必須)
- [x] チャンネルIDとユーザーIDの組み合わせ(重複禁止)

### デフォルト値の確認
- [x] 公開設定(デフォルト値：false)