### PR TITLE
ChannelPlaylistVideoモデルのテスト

### DIFF
--- a/app/models/channel_playlist_video.rb
+++ b/app/models/channel_playlist_video.rb
@@ -2,6 +2,8 @@ class ChannelPlaylistVideo < ApplicationRecord
   belongs_to :channel_playlist
   belongs_to :video
 
+  validates :channel_playlist_id, uniqueness: { scope: :video_id }
+
   class << self
     def update_playlist(playlist, videos)
       playlist.videos.delete_all unless playlist.videos.size == videos.size

--- a/spec/models/channel_playlist_video_spec.rb
+++ b/spec/models/channel_playlist_video_spec.rb
@@ -8,16 +8,23 @@ RSpec.describe ChannelPlaylistVideo, type: :model do
       expect(channel_playlist_video.errors).to be_empty
     end
 
-    it 'video_idがない場合にバリデーションが機能してinvalidになるか' do
+    it '動画IDがない場合にバリデーションが機能してinvalidになるか' do
       channel_playlist_video_without_video_id = build(:channel_playlist_video, video_id: nil)
       expect(channel_playlist_video_without_video_id).to be_invalid
       expect(channel_playlist_video_without_video_id.errors).to_not be_empty
     end
 
-    it 'channel_playlist_idがない場合にバリデーションが機能してinvalidになるか' do
+    it 'チャンネルプレイリストIDがない場合にバリデーションが機能してinvalidになるか' do
       channel_playlist_video_without_playlist_id = build(:channel_playlist_video, channel_playlist_id: nil)
       expect(channel_playlist_video_without_playlist_id).to be_invalid
       expect(channel_playlist_video_without_playlist_id.errors).to_not be_empty
+    end
+
+    it '動画IDとチャンネルプレイリストIDの組み合わせが既に存在している場合にバリデーションが機能してinvalidになるか' do
+      channel_playlist_video = create(:channel_playlist_video)
+      duplicate_channel_playlist_video = channel_playlist_video.dup
+      expect(duplicate_channel_playlist_video).to be_invalid
+      expect(duplicate_channel_playlist_video.errors).to_not be_empty
     end
   end
 end


### PR DESCRIPTION
## 変更の概要

* ChannelPlaylistVideoモデルのテスト項目作成&テスト実装
* Close #209 

## テスト項目

### バリデーションチェック
- [x] チャンネルプレイリストID(必須)
- [x] 動画ID(必須)
- [x] チャンネルプレイリストIDと動画IDの組み合わせ(重複禁止)