### PR TITLE
ChannelCommentモデルのテスト

### DIFF
--- a/spec/models/channel_comment_spec.rb
+++ b/spec/models/channel_comment_spec.rb
@@ -8,25 +8,25 @@ RSpec.describe ChannelComment, type: :model do
       expect(channel_comment.errors).to be_empty
     end
 
-    it 'bodyがない場合にバリデーションが機能してinvalidになるか' do
+    it 'コメント内容がない場合にバリデーションが機能してinvalidになるか' do
       channel_comment_without_body = build(:channel_comment, body: '')
       expect(channel_comment_without_body).to be_invalid
       expect(channel_comment_without_body.errors.full_messages).to include "コメントを入力してください"
     end
 
-    it 'bodyが401文字以上の場合にvalidationが機能してinvalidになるか' do
+    it 'コメント内容が401文字以上の場合にvalidationが機能してinvalidになるか' do
       channel_comment_with_long_body = build(:channel_comment, body: "a" * 401)
       expect(channel_comment_with_long_body).to be_invalid
       expect(channel_comment_with_long_body.errors.full_messages).to include "コメントは400文字以内で入力してください"
     end
 
-    it 'user_idがない場合にバリデーションが機能してinvalidになるか' do
+    it 'ユーザーIDがない場合にバリデーションが機能してinvalidになるか' do
       channel_comment_without_user_id = build(:channel_comment, user: nil)
       expect(channel_comment_without_user_id).to be_invalid
       expect(channel_comment_without_user_id.errors).to_not be_empty
     end
 
-    it 'channel_idがない場合にバリデーションが機能してinvalidになるか' do
+    it 'チャンネルIDがない場合にバリデーションが機能してinvalidになるか' do
       channel_comment_without_channel_id = build(:channel_comment, channel: nil)
       expect(channel_comment_without_channel_id).to be_invalid
       expect(channel_comment_without_channel_id.errors).to_not be_empty


### PR DESCRIPTION
## 変更の概要

* ChannelCommentモデルのテスト項目作成&テスト実装
* Close #204 

## テスト項目

### バリデーションチェック
- [x] ユーザーID(必須)
- [x] チャンネルID(必須)
- [x] コメント内容(必須)
- [x] コメント内容(400字以内)