### PR TITLE
VideoCommentモデルのテスト

### DIFF
--- a/spec/models/video_comment_spec.rb
+++ b/spec/models/video_comment_spec.rb
@@ -8,25 +8,25 @@ RSpec.describe VideoComment, type: :model do
       expect(video_comment.errors).to be_empty
     end
 
-    it 'bodyがない場合にバリデーションが機能してinvalidになるか' do
+    it 'コメント内容がない場合にバリデーションが機能してinvalidになるか' do
       video_comment_without_body = build(:video_comment, body: '')
       expect(video_comment_without_body).to be_invalid
       expect(video_comment_without_body.errors.full_messages).to include "コメントを入力してください"
     end
 
-    it 'bodyが401文字以上の場合にvalidationが機能してinvalidになるか' do
+    it 'コメント内容が401文字以上の場合にvalidationが機能してinvalidになるか' do
       video_comment_with_long_body = build(:video_comment, body: "a" * 401)
       expect(video_comment_with_long_body).to be_invalid
       expect(video_comment_with_long_body.errors.full_messages).to include "コメントは400文字以内で入力してください"
     end
 
-    it 'user_idがない場合にバリデーションが機能してinvalidになるか' do
+    it 'ユーザーIDがない場合にバリデーションが機能してinvalidになるか' do
       video_comment_without_user_id = build(:video_comment, user: nil)
       expect(video_comment_without_user_id).to be_invalid
       expect(video_comment_without_user_id.errors).to_not be_empty
     end
 
-    it 'video_idがない場合にバリデーションが機能してinvalidになるか' do
+    it 'ビデオIDがない場合にバリデーションが機能してinvalidになるか' do
       video_comment_without_video_id = build(:video_comment, video: nil)
       expect(video_comment_without_video_id).to be_invalid
       expect(video_comment_without_video_id.errors).to_not be_empty


### PR DESCRIPTION
## 変更の概要

* VideoCommentモデルのテスト項目作成&テスト実装
* Close #205 

## テスト項目

### バリデーションチェック
- [x] ユーザーID(必須)
- [x] ビデオID(必須)
- [x] コメント内容(必須)
- [x] コメント内容(400字以内)